### PR TITLE
Add terms and policies

### DIFF
--- a/index.md
+++ b/index.md
@@ -14,6 +14,10 @@ title: Clever
 
 [github.com/Clever/saml2](https://github.com/Clever/saml2)
 
+### Terms and Policies
+
+Clever's Terms and Policies are open source making it easy for people to view changes and historical information [github.com/Clever/policies](https://github.com/Clever/policies)
+
 
 ## Engineering Blog
 

--- a/index.md
+++ b/index.md
@@ -8,11 +8,12 @@ title: Clever
 
 ### Clever Components
 
-[clever.github.io/components](https://clever.github.io/components/)
+A design system for the ed-tech ecosystem [clever.github.io/components](https://clever.github.io/components/)
 
 ### SAML 2
 
-[github.com/Clever/saml2](https://github.com/Clever/saml2)
+
+Node module to abstract away the complexities of the SAML protocol behind an easy to use interface [github.com/Clever/saml2](https://github.com/Clever/saml2)
 
 ### Terms and Policies
 


### PR DESCRIPTION
Do we want to add a link to our open source terms and policies here, or should this space be reserved for more engineering centric projects like source code repositories? 🤔